### PR TITLE
Add flag to force using the same ASF frame number

### DIFF
--- a/isce2gimp/cli/prep_stack.py
+++ b/isce2gimp/cli/prep_stack.py
@@ -56,6 +56,11 @@ def cmdLineParse():
     parser.add_argument(
         "-f", type=int, dest="frame", required=True, help="ASF Frame"
     )
+    parser.add_argument(
+        "-m", dest="match_frame", required=False, default=False,  action='store_true', 
+        help="use exact frame number match"
+    )
+
 
     return parser
 
@@ -149,10 +154,13 @@ def main():
     else:
         raise ValueError('must supply either -r or -s')
     
-    # Since framing of consecutive frames don't always line up, find overlaps
-    gf = gf[startInd:startInd+200]
-    gf['overlap'] = get_overlap_area(gf, gfREF)
-    gf = gf.query('overlap >= 0.1').reset_index()
+    if inps.match_frame:
+        gf = gfREF.loc[startInd:]
+    else:
+        # Since framing of consecutive frames don't always line up, find overlaps
+        gf = gf[startInd:startInd+200]
+        gf['overlap'] = get_overlap_area(gf, gfREF)
+        gf = gf.query('overlap >= 0.1').reset_index()
     
     select_orbits = gf.orbit.unique()
     for i in range(inps.npairs):

--- a/isce2gimp/cli/query_inventory.py
+++ b/isce2gimp/cli/query_inventory.py
@@ -36,6 +36,9 @@ def cmdLineParse():
         required=True,
         help="Path/Track/RelativeOrbit Number",
     )
+    parser.add_argument(
+        "-f", type=int, dest="frame", required=False, help="frame number"
+    )
 
     return parser
 
@@ -54,6 +57,9 @@ def main():
     
     if inps.end:
         gf = gf.query('startTime <= @inps.end')
+    
+    if inps.frame:
+        gf = gf.query('frameNumber == @inps.frame')
 
     gf['date'] = gf.startTime.str[:10]
     print(gf.groupby(['date','orbit','platform']).frameNumber.agg(lambda x: list(x)).to_string())

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -43,6 +43,11 @@ def test_prep_stack(tmpdir):
         for outdir in outdirs:
             assert os.path.isdir(outdir)
 
+def test_aligned_frames(tmpdir):
+    with run_in(tmpdir):
+        cmd = shlex.split('prep_stack -p 83 -f 374 -s 2021-09-04 -n 1 -m')
+        p = subprocess.run(cmd)
+        assert os.path.isdir("83-374-39530-39705")
 
 def test_unaligned_frames(tmpdir):
     with run_in(tmpdir):


### PR DESCRIPTION
* added `-m` (match_frame) boolean to `prep_stack` to enforce using the same frame number in pairs. This effectively will only use single satellite acquisitions if S1A and S1B frames are offset: 

* added `-f` option to query_inventory to see summary restricted to a specific frame:

`query_inventory -p 83 -f 374 -s 2021-09-04`
```
date        orbit  platform   
2021-09-04  39530  Sentinel-1A    [374]
2021-09-16  39705  Sentinel-1A    [374]
2021-09-28  39880  Sentinel-1A    [374]
2021-10-10  40055  Sentinel-1A    [374]
```

`query_inventory -p 83 -s 2021-09-04`
```
date        orbit  platform   
2021-09-04  39530  Sentinel-1A    [368, 374, 379, 384, 389, 394]
2021-09-10  28634  Sentinel-1B         [370, 375, 381, 385, 390]
2021-09-16  39705  Sentinel-1A    [368, 374, 379, 384, 389, 394]
2021-09-22  28809  Sentinel-1B         [370, 375, 381, 385, 390]
```

cc @fastice 
