### PR TITLE
ASF Inventory Fixes

### DIFF
--- a/isce2gimp/cli/query_inventory.py
+++ b/isce2gimp/cli/query_inventory.py
@@ -2,7 +2,12 @@
 '''
 print range of values (unique dates), absolute orbits for a given path
 
-Usage: ./query_inventory -p 83 -s 2019-01-01 -e 2021-01-01
+Usage: 
+
+query_inventory -p 83 -s 2019-01-01 -e 2021-01-01
+query_inventory -p 17 -f 211
+query_inventory -p 17 -f 211 -a 19864
+
 
 various tabuler summaries 
 print(gf.groupby(['date','platform']).frameNumber.agg(lambda x: list(x)).to_string())
@@ -13,6 +18,8 @@ import argparse
 import geopandas as gpd
 import pandas as pd
 import os
+import sys
+from isce2gimp.cli.update_inventory import read_all_layers
 from pathlib import Path
 
 pd.options.mode.chained_assignment = None  # default='warn'
@@ -33,11 +40,14 @@ def cmdLineParse():
         "-p",
         type=int,
         dest="path",
-        required=True,
+        required=False,
         help="Path/Track/RelativeOrbit Number",
     )
     parser.add_argument(
         "-f", type=int, dest="frame", required=False, help="frame number"
+    )
+    parser.add_argument(
+        "-a", type=int, dest="absolute_orbit", required=False, help="absolute orbit number"
     )
 
     return parser
@@ -46,11 +56,21 @@ def main():
     """Run as a script with args coming from argparse."""
     parser = cmdLineParse()
     inps = parser.parse_args()
-    
-    print(f'Reading {INVENTORY} for relative orbit {inps.path}...')
-    gf = gpd.read_file(INVENTORY, layer=str(inps.path))
-    print(len(gf),'acquisitions in inventory')
-    print(len(gf.orbit.unique()),'orbits')
+
+    if inps.path:
+        print(f'Reading {INVENTORY} for relative orbit {inps.path}...')
+        gf = gpd.read_file(INVENTORY, layer=str(inps.path))
+        print(len(gf),'acquisitions in inventory')
+        print(len(gf.orbit.unique()),'orbits')
+    else:
+        parser.print_help(sys.stderr)
+        print(f'Generating full summary for {INVENTORY}...')
+        gf = read_all_layers(INVENTORY)
+        print('Total frames=',len(gf))
+        summary = gf.groupby(['pathNumber']).agg(dict(sceneName='count', frameNumber='nunique', orbit='nunique',startTime='min', stopTime='max'))
+        summary = summary.rename(columns={'sceneName':'totalScenes','frameNumber':'uniqueFrames','orbit':'relativeOrbits'}) 
+        print(summary)
+        sys.exit()
 
     if inps.start:
         gf = gf.query('startTime >= @inps.start')
@@ -62,7 +82,11 @@ def main():
         gf = gf.query('frameNumber == @inps.frame')
 
     gf['date'] = gf.startTime.str[:10]
-    print(gf.groupby(['date','orbit','platform']).frameNumber.agg(lambda x: list(x)).to_string())
+
+    if inps.absolute_orbit:
+        print(gf.query('orbit == @inps.absolute_orbit').T.drop('geometry').to_string())
+    else:
+        print(gf.groupby(['date','orbit','platform']).frameNumber.agg(lambda x: list(x)).to_string())
 
 if __name__ == "__main__":
     main() 


### PR DESCRIPTION
- fixes and error where startTime was used instead of stopTime resulting in duplicate frames
- adds more functionality to `query_inventory`
   - no input arguments results in a full inventory summary
   - you can get info for a specific frame `query_inventory -p 17 -f 211 -a 19864`
   
cc @fastice 