### PR TITLE
fix npairs and enddate logic

### DIFF
--- a/isce2gimp/cli/prep_stack.py
+++ b/isce2gimp/cli/prep_stack.py
@@ -142,6 +142,8 @@ def main():
     print("temporal span:") 
     print(gf.startTime.min(), gf.stopTime.max())
 
+    print(f'requested number of pairs (-n):  ', inps.npairs)
+
     if inps.end:
         gf = gf.query('stopTime <= @inps.end')
         print("cropped span:")
@@ -172,8 +174,12 @@ def main():
         gf['overlap'] = get_overlap_area(gf, gfREF)
         gf = gf.query('overlap >= 0.1').reset_index()
    
+    # Use requested 'npairs' up to end date
     select_orbits = gf.orbit.unique()
     NPAIRS = len(select_orbits)-1
+    if inps.npairs < NPAIRS:
+        NPAIRS = inps.npairs
+    
     for i in range(NPAIRS):
         inps.reference = select_orbits[i]
         inps.secondary = select_orbits[i+1]

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -47,10 +47,20 @@ def test_custom_template(tmpdir):
         assert "<property name='doionospherecorrection'>False</property>" in links
 
 def test_prep_stack_enddate(tmpdir):
+    # If more pairs requested than exist through enddate, enddate takes precedence
     with run_in(tmpdir):
         cmd = shlex.split('prep_stack -p 83 -f 374 -s 2020-06-01 -e 2020-07-01 -m -n 50')
         p = subprocess.run(cmd)
         outdirs = ["tmp-data-83", "83-374-32880-33055", "83-374-33055-33230"]
+        for outdir in outdirs:
+            assert os.path.isdir(outdir)
+
+def test_prep_stack_npairs(tmpdir):
+    # if fewer pairs requested than exist in temporal range, make sure just n pairs are used
+    with run_in(tmpdir):
+        cmd = shlex.split('prep_stack -p 83 -s 2019-01-01 -e 2021-01-01 -f 368 -n 2')
+        p = subprocess.run(cmd)
+        outdirs = ["tmp-data-83", "83-368-14284-25355", "83-368-25355-14459"]
         for outdir in outdirs:
             assert os.path.isdir(outdir)
 


### PR DESCRIPTION
if fewer pairs requested than exist in temporal range, make sure just n pairs are used

cc @fastice 